### PR TITLE
Fixing GetPadBuf ODR violation

### DIFF
--- a/include/ny_psyq.h
+++ b/include/ny_psyq.h
@@ -66,21 +66,20 @@ return 0;
 // Net Yaroze only uses the first 8 bytes, no multitap etc
 #define MAX_CONTROLLER_BYTES     8      /*  34 Size of the biggest packet  */
                                         /* You can possible have. From PSXDEV PSYQ ctrller.h       */
-inline void GetPadBuf(volatile unsigned char **pad0, volatile unsigned char **pad1)
+__attribute__((weak)) unsigned char GetPadBuf_pad_buff[2][MAX_CONTROLLER_BYTES];
+static inline void GetPadBuf(volatile unsigned char **pad0, volatile unsigned char **pad1)
 {
-    static unsigned char pad_buff[2][MAX_CONTROLLER_BYTES];
-	
 /* 
 PadInit(0);	// reset PAD
 This function initializes all connected controllers of the type specified by the mode parameter
 At present, only type 0 controllers are supported.
 This function is for prototyping purposes only.
 */
-	InitPAD ((char *)pad_buff[0], MAX_CONTROLLER_BYTES, (char *)pad_buff[1], MAX_CONTROLLER_BYTES);
+	InitPAD ((char *)GetPadBuf_pad_buff[0], MAX_CONTROLLER_BYTES, (char *)GetPadBuf_pad_buff[1], MAX_CONTROLLER_BYTES);
 	
 	StartPAD(); //Explanation - Triggered by the interruption of a vertical retrace line, this function starts to read the controller. ChangeClearPAD (1) is executed internally.
-	*pad0 = pad_buff[0];
-	*pad1 = pad_buff[1];
+	*pad0 = GetPadBuf_pad_buff[0];
+	*pad1 = GetPadBuf_pad_buff[1];
 
 
 /*
@@ -90,7 +89,7 @@ retrace line interrupt, or to pass processing to a lower priority interrupt modu
 value of 1 specifies completion, while a val value of 0 specifies passing.
 */
 	 for(int i = 0;i < MAX_CONTROLLER_BYTES; i++)
-         pad_buff[0][i] = pad_buff[1][i] = 0xff; // prime init pad results to nothing to 1's
+         GetPadBuf_pad_buff[0][i] = GetPadBuf_pad_buff[1][i] = 0xff; // prime init pad results to nothing to 1's
 }
 
 


### PR DESCRIPTION
As described in #1, the local static `pad_buff` may still get instantiated multiple times, if the function `GetPadBuf` is called from multiple compilation units.

This fix declares a global called `GetPadBuf_pad_buff`, with the `weak` attribute, ensuring that, even if the .h file is included multiple times, only one instance of it will end up in the final linked file, ensuring it to become a singleton.